### PR TITLE
fix: use fully qualified path for results

### DIFF
--- a/macro/src/gen/mod.rs
+++ b/macro/src/gen/mod.rs
@@ -54,7 +54,7 @@ fn gen_config_impl(input: &ir::Input) -> TokenStream {
         impl confique::Config for #name {
             type Partial = #partial_mod_name::#partial_struct_name;
 
-            fn from_partial(partial: Self::Partial) -> Result<Self, confique::Error> {
+            fn from_partial(partial: Self::Partial) -> std::result::Result<Self, confique::Error> {
                 Ok(Self {
                     #( #field_names: #from_exprs, )*
                 })
@@ -208,7 +208,7 @@ fn gen_partial_mod(input: &ir::Input) -> TokenStream {
                 let ty = kind.inner_ty();
 
                 Some(quote! {
-                    fn #fn_name<'de, D>(deserializer: D) -> Result<Option<#ty>, D::Error>
+                    fn #fn_name<'de, D>(deserializer: D) -> std::result::Result<Option<#ty>, D::Error>
                     where
                         D: serde::Deserializer<'de>,
                     {
@@ -251,7 +251,7 @@ fn gen_partial_mod(input: &ir::Input) -> TokenStream {
                     }
                 }
 
-                fn from_env() -> Result<Self, confique::Error> {
+                fn from_env() -> std::result::Result<Self, confique::Error> {
                     Ok(Self {
                         #( #field_names: #from_env_fields, )*
                     })


### PR DESCRIPTION
Hi, thanks for making this great library. I had a small issue where the `Config` macro was failing to compile because I had `use crate::Result` at the top of my file which conflicted with the unqualified use of `Result` in the macros. This switches the macro to use the fully qualified import during code generation to avoid conflicts.