### PR TITLE
Treat deserialization errors from empty env vars as unset env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,9 @@ pub use crate::{
 /// Assigns an environment variable to this field. In [`Partial::from_env`], the
 /// variable is checked and deserialized into the field if present.
 ///
+/// If the env var is set to an empty string and if the field fails to
+/// parse/deserialize from it, it is treated as unset.
+///
 /// ### `parse_env`
 ///
 /// ```ignore

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
-use confique::{Config};
+use confique::{Config, Partial};
+use pretty_assertions::assert_eq;
 
 #[derive(Debug, Deserialize)]
 enum Foo { A, B, C }
@@ -16,4 +17,48 @@ fn enum_env() {
     std::env::set_var("FOO", "B");
     let conf = Conf::builder().env().load();
     assert!(matches!(conf, Ok(Conf { foo: Foo::B })));
+}
+
+fn my_parser(s: &str) -> Result<u32, impl std::error::Error> {
+    s.trim().parse()
+}
+
+#[test]
+fn empty_error_is_unset() {
+    #[derive(Config)]
+    #[config(partial_attr(derive(PartialEq, Debug)))]
+    #[allow(dead_code)]
+    struct Conf {
+        #[config(env = "EMPTY_ERROR_IS_UNSET_FOO")]
+        foo: u32,
+
+        #[config(env = "EMPTY_ERROR_IS_UNSET_BAR", parse_env = my_parser)]
+        bar: u32,
+
+        #[config(env = "EMPTY_ERROR_IS_UNSET_BAZ")]
+        baz: String,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+    std::env::set_var("EMPTY_ERROR_IS_UNSET_FOO", "");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        foo: None,
+        bar: None,
+        baz: None,
+    });
+
+    std::env::set_var("EMPTY_ERROR_IS_UNSET_BAR", "");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        foo: None,
+        bar: None,
+        baz: None,
+    });
+
+    std::env::set_var("EMPTY_ERROR_IS_UNSET_BAZ", "");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        foo: None,
+        bar: None,
+        baz: Some("".into()),
+    });
 }


### PR DESCRIPTION
@jdx what do you think about this potential solution to your issue?

---

Fixes #35

I'm a bit worried that this might seem too much like magic, but I think this is just the most useful behavior in all situations I can think of. This covers not only Booleans, but also numbers and anything else for which an empty string is not a valid value. It also leaves types with empty strings as valid values untouched.

I've been thinking about how this behavior could confuse users. And I could only think of two cases:

- A config value has a default value, and the user thinks that empty string is a valid value, when in fact it isn't. Then, setting `FOO=` will result in the default value, when the user expected an empty string. Here, a clear error "empty string invalid" would be more helpful.

- A config value with a type that can be deserialized from empty string, but the user thinks it cannot. Maybe the config value is a list of numbers, where  "" is just an empty list, but the user thought it was a single number. Then setting `FOO=` means setting the value to an empty list.

Not sure if any of these cases will happen often enough or is important enough to not merge this?