### PR TITLE
Add Validation via `#[config(validate)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ name = "indirect-serde"
 path = "tests/indirect-serde/run.rs"
 harness = false
 
+[[test]]
+name = "validation"
+required-features = ["toml"]
+
 
 [features]
 default = ["toml", "yaml", "json5"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ exclude = [".github"]
 name = "simple"
 required-features = ["toml"]
 
+[[example]]
+name = "validate"
+required-features = ["toml"]
+
 [[test]]
 name = "indirect-serde"
 path = "tests/indirect-serde/run.rs"

--- a/examples/files/validate.toml
+++ b/examples/files/validate.toml
@@ -1,0 +1,6 @@
+name = "peter"
+port = 1234
+
+[watch]
+busy_poll = true
+poll_period = 300

--- a/examples/validate.rs
+++ b/examples/validate.rs
@@ -1,0 +1,82 @@
+//! This example demonstrates the usage of validators for single fields or whole
+//! structs. Try editing `files/validate.toml` to see different errors. Also
+//! see the docs.
+
+use std::time::Duration;
+
+use confique::Config;
+
+
+#[derive(Debug, Config)]
+#[allow(dead_code)]
+struct Conf {
+    // Here, the validator is a function returning `Result<(), impl Display>`.
+    #[config(validate = validate_name)]
+    name: String,
+
+    // For simple cases, validation can be written in this `assert!`-like style.
+    #[config(env = "PORT", validate(*port >= 1024, "port must not require super-user"))]
+    port: Option<u16>,
+
+    #[config(nested)]
+    watch: WatchConfig,
+}
+
+// You can also add validators for whole structs, which are called later in the
+// pipeline, when all layers are already merged. These validators allow you to
+// check fields in relationship to one another, e.g. maybe one field only makes
+// sense to be set whenever another one has a specific value.
+#[derive(Debug, Config)]
+#[config(validate = Self::validate)]
+struct WatchConfig {
+    #[config(default = false)]
+    busy_poll: bool,
+
+    #[config(
+        deserialize_with = deserialize_duration_ms,
+        validate(*poll_period > Duration::from_millis(10), "cannot poll faster than 10ms"),
+    )]
+    poll_period: Option<Duration>,
+}
+
+fn validate_name(name: &String) -> Result<(), &'static str> {
+    if name.is_empty() {
+        return Err("name must be non-empty");
+    }
+    if !name.is_ascii() {
+        return Err("name must be ASCII");
+    }
+    Ok(())
+}
+
+impl WatchConfig {
+    fn validate(&self) -> Result<(), &'static str> {
+        if !self.busy_poll && self.poll_period.is_some() {
+            return Err("'poll_period' set, but busy polling is not enabled");
+        }
+
+        Ok(())
+    }
+}
+
+
+pub(crate) fn deserialize_duration_ms<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let ms = <u64 as serde::Deserialize>::deserialize(deserializer)?;
+    Ok(Duration::from_millis(ms))
+}
+
+
+fn main() {
+    let r = Conf::builder()
+        .env()
+        .file("examples/files/validate.toml")
+        .load();
+
+    match r {
+        Ok(conf) => println!("{:#?}", conf),
+        Err(e) => println!("{e:#}"),
+    }
+}

--- a/macro/src/gen/mod.rs
+++ b/macro/src/gen/mod.rs
@@ -47,6 +47,9 @@ fn gen_config_impl(input: &ir::Input) -> TokenStream {
         }
     });
 
+    let validation = input.validate.as_ref().map(|v| quote! {
+        confique::internal::do_validate_struct(&out, &#v)?;
+    });
 
     let meta_item = meta::gen(input);
     quote! {
@@ -55,9 +58,11 @@ fn gen_config_impl(input: &ir::Input) -> TokenStream {
             type Partial = #partial_mod_name::#partial_struct_name;
 
             fn from_partial(partial: Self::Partial) -> std::result::Result<Self, confique::Error> {
-                std::result::Result::Ok(Self {
+                let out = Self {
                     #( #field_names: #from_exprs, )*
-                })
+                };
+                #validation
+                std::result::Result::Ok(out)
             }
 
             #meta_item

--- a/macro/src/ir.rs
+++ b/macro/src/ir.rs
@@ -8,6 +8,7 @@ pub(crate) struct Input {
     pub(crate) doc: Vec<String>,
     pub(crate) visibility: syn::Visibility,
     pub(crate) partial_attrs: Vec<TokenStream>,
+    pub(crate) validate: Option<syn::Path>,
     pub(crate) name: syn::Ident,
     pub(crate) fields: Vec<Field>,
 }
@@ -28,6 +29,7 @@ pub(crate) enum FieldKind {
         env: Option<String>,
         deserialize_with: Option<syn::Path>,
         parse_env: Option<syn::Path>,
+        validate: Option<syn::Path>,
         kind: LeafKind,
     },
 

--- a/macro/src/ir.rs
+++ b/macro/src/ir.rs
@@ -29,7 +29,7 @@ pub(crate) enum FieldKind {
         env: Option<String>,
         deserialize_with: Option<syn::Path>,
         parse_env: Option<syn::Path>,
-        validate: Option<syn::Path>,
+        validate: Option<FieldValidator>,
         kind: LeafKind,
     },
 
@@ -37,6 +37,11 @@ pub(crate) enum FieldKind {
     Nested {
         ty: syn::Type,
     },
+}
+
+pub(crate) enum FieldValidator {
+    Fn(syn::Path),
+    Simple(TokenStream, String),
 }
 
 pub(crate) enum LeafKind {

--- a/macro/src/parse.rs
+++ b/macro/src/parse.rs
@@ -174,10 +174,6 @@ impl Field {
             kind,
         })
     }
-
-    pub(crate) fn is_leaf(&self) -> bool {
-        matches!(self.kind, FieldKind::Leaf { .. })
-    }
 }
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,9 @@ pub(crate) enum ErrorInner {
 
     /// A file source was marked as required but the file does not exist.
     MissingRequiredFile { path: PathBuf },
+
+    /// When a struct validation function fails.
+    Validation { msg: String },
 }
 
 impl std::error::Error for Error {
@@ -90,6 +93,7 @@ impl std::error::Error for Error {
             ErrorInner::UnsupportedFileFormat { .. } => None,
             ErrorInner::MissingFileExtension { .. } => None,
             ErrorInner::MissingRequiredFile { .. } => None,
+            ErrorInner::Validation { .. } => None,
         }
     }
 }
@@ -159,6 +163,9 @@ impl fmt::Display for Error {
                     "required configuration file does not exist: '{}'",
                     path.display(),
                 )
+            }
+            ErrorInner::Validation { msg } => {
+                std::write!(f, "config validation failed: {msg}")
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,12 @@ pub struct Error {
     pub(crate) inner: Box<ErrorInner>,
 }
 
+impl Error {
+    pub(crate) fn field_validation(msg: impl fmt::Display) -> Self {
+        ErrorInner::FieldValidation { msg: msg.to_string() }.into()
+    }
+}
+
 // If all these features are disabled, lots of these errors are unused. But
 // instead of repeating this cfg-attribute a lot in the rest of the file, we
 // just live with these unused variants. It's not like we need to optimize the
@@ -77,8 +83,11 @@ pub(crate) enum ErrorInner {
     /// A file source was marked as required but the file does not exist.
     MissingRequiredFile { path: PathBuf },
 
+    /// When a field validation function fails.
+    FieldValidation { msg: String },
+
     /// When a struct validation function fails.
-    Validation { msg: String },
+    StructValidation { name: String, msg: String },
 }
 
 impl std::error::Error for Error {
@@ -93,7 +102,8 @@ impl std::error::Error for Error {
             ErrorInner::UnsupportedFileFormat { .. } => None,
             ErrorInner::MissingFileExtension { .. } => None,
             ErrorInner::MissingRequiredFile { .. } => None,
-            ErrorInner::Validation { .. } => None,
+            ErrorInner::FieldValidation { .. } => None,
+            ErrorInner::StructValidation { .. } => None,
         }
     }
 }
@@ -164,8 +174,11 @@ impl fmt::Display for Error {
                     path.display(),
                 )
             }
-            ErrorInner::Validation { msg } => {
-                std::write!(f, "config validation failed: {msg}")
+            ErrorInner::FieldValidation { msg } => {
+                std::write!(f, "validation failed: {msg}")
+            }
+            ErrorInner::StructValidation { name, msg } => {
+                std::write!(f, "config validation of `{name}` failed: {msg}")
             }
         }
     }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -49,6 +49,12 @@ pub fn field_validation_err<E: Display>(e: E) -> String {
     format!("validation error: {e}")
 }
 
+pub fn do_validate_struct<T, E>(t: &T, validate: &dyn Fn(&T) -> Result<(), E>) -> Result<(), Error>
+where
+    E: Display,
+{
+    validate(t).map_err(|msg| ErrorInner::Validation { msg: msg.to_string() }.into())
+}
 
 macro_rules! get_env_var {
     ($key:expr, $field:expr) => {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -42,7 +42,11 @@ pub fn do_validate_field<T, E>(t: &T, validate: &dyn Fn(&T) -> Result<(), E>) ->
 where
     E: Display,
 {
-    validate(t).map_err(|e| format!("validation error: {e}"))
+    validate(t).map_err(field_validation_err)
+}
+
+pub fn field_validation_err<E: Display>(e: E) -> String {
+    format!("validation error: {e}")
 }
 
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,13 +6,6 @@ use std::fmt::Display;
 
 use crate::{error::ErrorInner, Error};
 
-pub fn deserialize_default<I, O>(src: I) -> Result<O, serde::de::value::Error>
-where
-    I: for<'de> serde::de::IntoDeserializer<'de>,
-    O: for<'de> serde::Deserialize<'de>,
-{
-    O::deserialize(src.into_deserializer())
-}
 
 pub fn into_deserializer<'de, T>(src: T) -> <T as serde::de::IntoDeserializer<'de>>::Deserializer
 where
@@ -38,22 +31,22 @@ pub fn map_err_prefix_path<T>(res: Result<T, Error>, prefix: &str) -> Result<T, 
     })
 }
 
-pub fn do_validate_field<T, E>(t: &T, validate: &dyn Fn(&T) -> Result<(), E>) -> Result<(), String>
-where
-    E: Display,
-{
-    validate(t).map_err(field_validation_err)
+pub fn validate_field<T, E: Display>(
+    t: &T,
+    validate: &dyn Fn(&T) -> Result<(), E>,
+) -> Result<(), Error> {
+    validate(t).map_err(Error::field_validation)
 }
 
-pub fn field_validation_err<E: Display>(e: E) -> String {
-    format!("validation error: {e}")
-}
-
-pub fn do_validate_struct<T, E>(t: &T, validate: &dyn Fn(&T) -> Result<(), E>) -> Result<(), Error>
-where
-    E: Display,
-{
-    validate(t).map_err(|msg| ErrorInner::Validation { msg: msg.to_string() }.into())
+pub fn validate_struct<T, E: Display>(
+    t: &T,
+    validate: &dyn Fn(&T) -> Result<(), E>,
+    struct_name: &'static str,
+) -> Result<(), Error> {
+    validate(t).map_err(|msg| ErrorInner::StructValidation {
+        name: struct_name.into(),
+        msg: msg.to_string()
+    }.into())
 }
 
 macro_rules! get_env_var {
@@ -72,34 +65,7 @@ macro_rules! get_env_var {
     };
 }
 
-pub fn from_env<'de, T: serde::Deserialize<'de>>(
-    key: &str,
-    field: &str,
-) -> Result<Option<T>, Error> {
-    from_env_with_deserializer(key, field, |de| T::deserialize(de))
-}
-
-pub fn from_env_with_parser<T, E: std::error::Error + Send + Sync + 'static>(
-    key: &str,
-    field: &str,
-    parse: fn(&str) -> Result<T, E>,
-) -> Result<Option<T>, Error> {
-    let v = get_env_var!(key, field);
-    let is_empty = v.is_empty();
-    match parse(&v) {
-        Ok(v) => Ok(Some(v)),
-        Err(_) if is_empty => Ok(None),
-        Err(err) => Err(
-            ErrorInner::EnvParseError {
-                field: field.to_owned(),
-                key: key.to_owned(),
-                err: Box::new(err),
-            }.into()
-        ),
-    }
-}
-
-pub fn from_env_with_deserializer<T>(
+pub fn from_env<T>(
     key: &str,
     field: &str,
     deserialize: fn(crate::env::Deserializer) -> Result<T, crate::env::DeError>,
@@ -115,6 +81,33 @@ pub fn from_env_with_deserializer<T>(
             field: field.into(),
             msg: e.0,
         }.into()),
+    }
+}
+
+pub fn from_env_with_parser<T, E: std::error::Error + Send + Sync + 'static, E2: Display>(
+    key: &str,
+    field: &str,
+    parse: fn(&str) -> Result<T, E>,
+    validate: fn(&T) -> Result<(), E2>,
+) -> Result<Option<T>, Error> {
+    let v = get_env_var!(key, field);
+    let is_empty = v.is_empty();
+    match parse(&v) {
+        Ok(v) => {
+            match validate(&v).map_err(Error::field_validation) {
+                Ok(()) => Ok(Some(v)),
+                Err(_) if is_empty => Ok(None),
+                Err(e) => Err(e),
+            }
+        },
+        Err(_) if is_empty => Ok(None),
+        Err(err) => Err(
+            ErrorInner::EnvParseError {
+                field: field.to_owned(),
+                key: key.to_owned(),
+                err: Box::new(err),
+            }.into()
+        ),
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,6 +2,8 @@
 //! intended to be used directly. None of this is covered by semver! Do not use
 //! any of this directly.
 
+use std::fmt::Display;
+
 use crate::{error::ErrorInner, Error};
 
 pub fn deserialize_default<I, O>(src: I) -> Result<O, serde::de::value::Error>
@@ -34,6 +36,13 @@ pub fn map_err_prefix_path<T>(res: Result<T, Error>, prefix: &str) -> Result<T, 
             e
         }
     })
+}
+
+pub fn do_validate_field<T, E>(t: &T, validate: &dyn Fn(&T) -> Result<(), E>) -> Result<(), String>
+where
+    E: Display,
+{
+    validate(t).map_err(|e| format!("validation error: {e}"))
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub use crate::{
 /// variable is checked and deserialized into the field if present.
 ///
 /// If the env var is set to an empty string and if the field fails to
-/// parse/deserialize from it, it is treated as unset.
+/// parse/deserialize/validate, it is treated as unset.
 ///
 /// ### `parse_env`
 ///

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -23,6 +23,14 @@ fn my_parser(s: &str) -> Result<u32, impl std::error::Error> {
     s.trim().parse()
 }
 
+fn my_parser2(s: &str) -> Result<u32, impl std::error::Error> {
+    if s.is_empty() {
+        Ok(0)
+    } else {
+        s.trim().parse()
+    }
+}
+
 #[test]
 fn empty_error_is_unset() {
     #[derive(Config)]
@@ -37,6 +45,16 @@ fn empty_error_is_unset() {
 
         #[config(env = "EMPTY_ERROR_IS_UNSET_BAZ")]
         baz: String,
+
+        #[config(env = "EMPTY_ERROR_IS_UNSET_VALIDATE", validate(!validate.is_empty(), "bad"))]
+        validate: String,
+
+        #[config(
+            env = "EMPTY_ERROR_IS_UNSET_VALIDATE_PARSE",
+            parse_env = my_parser2,
+            validate(*validate_parse != 0, "bad"),
+        )]
+        validate_parse: u32,
     }
 
     type Partial = <Conf as Config>::Partial;
@@ -46,6 +64,8 @@ fn empty_error_is_unset() {
         foo: None,
         bar: None,
         baz: None,
+        validate: None,
+        validate_parse: None,
     });
 
     std::env::set_var("EMPTY_ERROR_IS_UNSET_BAR", "");
@@ -53,6 +73,8 @@ fn empty_error_is_unset() {
         foo: None,
         bar: None,
         baz: None,
+        validate: None,
+        validate_parse: None,
     });
 
     std::env::set_var("EMPTY_ERROR_IS_UNSET_BAZ", "");
@@ -60,5 +82,25 @@ fn empty_error_is_unset() {
         foo: None,
         bar: None,
         baz: Some("".into()),
+        validate: None,
+        validate_parse: None,
+    });
+
+    std::env::set_var("EMPTY_ERROR_IS_UNSET_VALIDATE", "");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        foo: None,
+        bar: None,
+        baz: Some("".into()),
+        validate: None,
+        validate_parse: None,
+    });
+
+    std::env::set_var("EMPTY_ERROR_IS_UNSET_VALIDATE_PARSE", "");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        foo: None,
+        bar: None,
+        baz: Some("".into()),
+        validate: None,
+        validate_parse: None,
     });
 }

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,536 @@
+use pretty_assertions::assert_eq;
+
+use confique::{Config, Partial};
+
+
+fn validate_not_1234(foo: &u32) -> Result<(), &'static str> {
+    if *foo == 1234 {
+        Err("bad password")
+    } else {
+        Ok(())
+    }
+}
+
+#[test]
+#[should_panic(expected = "default config value for `Conf::foo` cannot be \
+    deserialized: Error(\"validation failed: bad password\")")]
+fn invalid_default_panics_function() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    struct Conf {
+        #[config(default = 1234, validate = validate_not_1234)]
+        foo: u32,
+    }
+
+    let _ = <Conf as Config>::Partial::default_values();
+}
+
+#[test]
+#[should_panic(expected = "default config value for `Conf::foo` cannot be \
+    deserialized: Error(\"validation failed: ugly number\")")]
+fn invalid_default_panics_assert_like() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    struct Conf {
+        #[config(default = 1234, validate(*foo != 1234, "ugly number"))]
+        foo: u32,
+    }
+
+    let _ = <Conf as Config>::Partial::default_values();
+}
+
+#[test]
+fn assert_like() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    #[config(partial_attr(derive(Debug, PartialEq)))]
+    struct Conf {
+        #[config(
+            env = "AL_REQ",
+            validate(req.is_ascii(), "non-ASCII characters ~req are not allowed"),
+        )]
+        req: String,
+
+        #[config(
+            env = "AL_DEF",
+            default = "root",
+            validate(def.is_ascii(), "non-ASCII characters ~def are not allowed"),
+        )]
+        def: String,
+
+        #[config(
+            env = "AL_OPT",
+            validate(opt.is_ascii(), "non-ASCII characters ~opt are not allowed"),
+        )]
+        opt: Option<String>,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+    // Defaults
+    assert_eq!(Partial::default_values(), Partial {
+        req: None,
+        def: Some("root".into()),
+        opt: None,
+    });
+
+
+    // From env
+    std::env::set_var("AL_REQ", "jürgen");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~req are not allowed");
+    std::env::set_var("AL_REQ", "cat");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: None,
+        opt: None,
+    });
+
+    std::env::set_var("AL_DEF", "I ❤️ fluffy animals");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~def are not allowed");
+    std::env::set_var("AL_DEF", "dog");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: Some("dog".into()),
+        opt: None,
+    });
+
+    std::env::set_var("AL_OPT", "Μου αρέσουν τα χνουδωτά ζώα");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~opt are not allowed");
+    std::env::set_var("AL_OPT", "fox");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: Some("dog".into()),
+        opt: Some("fox".into()),
+    });
+
+
+    // From file
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"req = "jürgen""#),
+        "non-ASCII characters ~req are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"def = "I ❤️ fluffy animals""#),
+        "non-ASCII characters ~def are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"opt = "Μου αρέσουν τα χνουδωτά ζώα""#),
+        "non-ASCII characters ~opt are not allowed",
+    );
+    assert_eq!(
+        toml::from_str::<Partial>("req = \"cat\"\ndef = \"dog\"\nopt = \"fox\"").unwrap(),
+        Partial {
+            req: Some("cat".into()),
+            def: Some("dog".into()),
+            opt: Some("fox".into()),
+        },
+    );
+}
+
+fn assert_is_ascii(s: &String) -> Result<(), &'static str> {
+    if !s.is_ascii() {
+        Err("non-ASCII characters are not allowed")
+    } else {
+        Ok(())
+    }
+}
+
+#[test]
+fn function() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    #[config(partial_attr(derive(Debug, PartialEq)))]
+    struct Conf {
+        #[config(env = "FN_REQ", validate = assert_is_ascii)]
+        req: String,
+
+        #[config(env = "FN_DEF", default = "root", validate = assert_is_ascii)]
+        def: String,
+
+        #[config(env = "FN_OPT", validate = assert_is_ascii)]
+        opt: Option<String>,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+    // Defaults
+    assert_eq!(Partial::default_values(), Partial {
+        req: None,
+        def: Some("root".into()),
+        opt: None,
+    });
+
+
+    // From env
+    std::env::set_var("FN_REQ", "jürgen");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FN_REQ", "cat");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: None,
+        opt: None,
+    });
+
+    std::env::set_var("FN_DEF", "I ❤️ fluffy animals");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FN_DEF", "dog");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: Some("dog".into()),
+        opt: None,
+    });
+
+    std::env::set_var("FN_OPT", "Μου αρέσουν τα χνουδωτά ζώα");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FN_OPT", "fox");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat".into()),
+        def: Some("dog".into()),
+        opt: Some("fox".into()),
+    });
+
+
+    // From file
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"req = "jürgen""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"def = "I ❤️ fluffy animals""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"opt = "Μου αρέσουν τα χνουδωτά ζώα""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_eq!(
+        toml::from_str::<Partial>("req = \"cat\"\ndef = \"dog\"\nopt = \"fox\"").unwrap(),
+        Partial {
+            req: Some("cat".into()),
+            def: Some("dog".into()),
+            opt: Some("fox".into()),
+        },
+    );
+}
+
+fn deserialize_append<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let mut s = <String as serde::Deserialize>::deserialize(deserializer)?;
+    s.push_str("-henlo");
+    Ok(s)
+}
+
+#[test]
+fn assert_like_with_deserializer() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    #[config(partial_attr(derive(Debug, PartialEq)))]
+    struct Conf {
+        #[config(
+            env = "ALD_REQ",
+            deserialize_with = deserialize_append,
+            validate(req.is_ascii(), "non-ASCII characters ~req are not allowed"),
+        )]
+        req: String,
+
+        #[config(
+            env = "ALD_DEF",
+            default = "root",
+            deserialize_with = deserialize_append,
+            validate(def.is_ascii(), "non-ASCII characters ~def are not allowed"),
+        )]
+        def: String,
+
+        #[config(
+            env = "ALD_OPT",
+            deserialize_with = deserialize_append,
+            validate(opt.is_ascii(), "non-ASCII characters ~opt are not allowed"),
+        )]
+        opt: Option<String>,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+    // Defaults
+    assert_eq!(Partial::default_values(), Partial {
+        req: None,
+        def: Some("root-henlo".into()),
+        opt: None,
+    });
+
+
+    // From env
+    std::env::set_var("ALD_REQ", "jürgen");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~req are not allowed");
+    std::env::set_var("ALD_REQ", "cat");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: None,
+        opt: None,
+    });
+
+    std::env::set_var("ALD_DEF", "I ❤️ fluffy animals");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~def are not allowed");
+    std::env::set_var("ALD_DEF", "dog");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: Some("dog-henlo".into()),
+        opt: None,
+    });
+
+    std::env::set_var("ALD_OPT", "Μου αρέσουν τα χνουδωτά ζώα");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters ~opt are not allowed");
+    std::env::set_var("ALD_OPT", "fox");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: Some("dog-henlo".into()),
+        opt: Some("fox-henlo".into()),
+    });
+
+
+    // From file
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"req = "jürgen""#),
+        "non-ASCII characters ~req are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"def = "I ❤️ fluffy animals""#),
+        "non-ASCII characters ~def are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"opt = "Μου αρέσουν τα χνουδωτά ζώα""#),
+        "non-ASCII characters ~opt are not allowed",
+    );
+    assert_eq!(
+        toml::from_str::<Partial>("req = \"cat\"\ndef = \"dog\"\nopt = \"fox\"").unwrap(),
+        Partial {
+            req: Some("cat-henlo".into()),
+            def: Some("dog-henlo".into()),
+            opt: Some("fox-henlo".into()),
+        },
+    );
+}
+
+#[test]
+fn function_with_deserializer() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    #[config(partial_attr(derive(Debug, PartialEq)))]
+    struct Conf {
+        #[config(
+            env = "FND_REQ",
+            validate = assert_is_ascii,
+            deserialize_with = deserialize_append,
+        )]
+        req: String,
+
+        #[config(
+            env = "FND_DEF",
+            default = "root",
+            validate = assert_is_ascii,
+            deserialize_with = deserialize_append,
+        )]
+        def: String,
+
+        #[config(
+            env = "FND_OPT",
+            validate = assert_is_ascii,
+            deserialize_with = deserialize_append,
+        )]
+        opt: Option<String>,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+    // Defaults
+    assert_eq!(Partial::default_values(), Partial {
+        req: None,
+        def: Some("root-henlo".into()),
+        opt: None,
+    });
+
+
+    // From env
+    std::env::set_var("FND_REQ", "jürgen");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FND_REQ", "cat");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: None,
+        opt: None,
+    });
+
+    std::env::set_var("FND_DEF", "I ❤️ fluffy animals");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FND_DEF", "dog");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: Some("dog-henlo".into()),
+        opt: None,
+    });
+
+    std::env::set_var("FND_OPT", "Μου αρέσουν τα χνουδωτά ζώα");
+    assert_err_contains(Partial::from_env(), "non-ASCII characters are not allowed");
+    std::env::set_var("FND_OPT", "fox");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        req: Some("cat-henlo".into()),
+        def: Some("dog-henlo".into()),
+        opt: Some("fox-henlo".into()),
+    });
+
+
+    // From file
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"req = "jürgen""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"def = "I ❤️ fluffy animals""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_err_contains(
+        toml::from_str::<Partial>(r#"opt = "Μου αρέσουν τα χνουδωτά ζώα""#),
+        "non-ASCII characters are not allowed",
+    );
+    assert_eq!(
+        toml::from_str::<Partial>("req = \"cat\"\ndef = \"dog\"\nopt = \"fox\"").unwrap(),
+        Partial {
+            req: Some("cat-henlo".into()),
+            def: Some("dog-henlo".into()),
+            opt: Some("fox-henlo".into()),
+        },
+    );
+}
+
+fn validate_vec(v: &Vec<u32>) -> Result<(), &'static str> {
+    if v.len() < 3  {
+        return Err("list too short");
+    }
+    Ok(())
+}
+
+#[test]
+fn parse_env() {
+    #[derive(Config)]
+    #[allow(dead_code)]
+    #[config(partial_attr(derive(Debug, PartialEq)))]
+    struct Conf {
+        #[config(
+            env = "PE_FUN",
+            parse_env = confique::env::parse::list_by_comma,
+            validate = validate_vec,
+        )]
+        function: Vec<u32>,
+
+        #[config(
+            env = "PE_AL",
+            parse_env = confique::env::parse::list_by_colon,
+            validate(assert_like.len() >= 3, "list too ~req short"),
+        )]
+        assert_like: Vec<u32>,
+
+        #[config(
+            env = "PE_FUN_OPT",
+            parse_env = confique::env::parse::list_by_semicolon,
+            validate = validate_vec,
+        )]
+        function_opt: Option<Vec<u32>>,
+
+        #[config(
+            env = "PE_AL_OPT",
+            parse_env = confique::env::parse::list_by_space,
+            validate(assert_like_opt.len() >= 3, "list too ~opt short"),
+        )]
+        assert_like_opt: Option<Vec<u32>>,
+    }
+
+    type Partial = <Conf as Config>::Partial;
+
+
+    std::env::set_var("PE_FUN", "1,2");
+    assert_err_contains(Partial::from_env(), "list too short");
+    std::env::set_var("PE_FUN", "1,2,3");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        function: Some(vec![1, 2, 3]),
+        assert_like: None,
+        function_opt: None,
+        assert_like_opt: None,
+    });
+
+    std::env::set_var("PE_AL", "1:2");
+    assert_err_contains(Partial::from_env(), "list too ~req short");
+    std::env::set_var("PE_AL", "1:2:3");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        function: Some(vec![1, 2, 3]),
+        assert_like: Some(vec![1, 2, 3]),
+        function_opt: None,
+        assert_like_opt: None,
+    });
+
+    std::env::set_var("PE_FUN_OPT", "1;2");
+    assert_err_contains(Partial::from_env(), "list too short");
+    std::env::set_var("PE_FUN_OPT", "1;2;3");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        function: Some(vec![1, 2, 3]),
+        assert_like: Some(vec![1, 2, 3]),
+        function_opt: Some(vec![1, 2, 3]),
+        assert_like_opt: None,
+    });
+
+    std::env::set_var("PE_AL_OPT", "1 2");
+    assert_err_contains(Partial::from_env(), "list too ~opt short");
+    std::env::set_var("PE_AL_OPT", "1 2 3");
+    assert_eq!(Partial::from_env().unwrap(), Partial {
+        function: Some(vec![1, 2, 3]),
+        assert_like: Some(vec![1, 2, 3]),
+        function_opt: Some(vec![1, 2, 3]),
+        assert_like_opt: Some(vec![1, 2, 3]),
+    });
+}
+
+#[test]
+fn struct_validation() {
+    #[derive(Config, PartialEq, Debug)]
+    #[allow(dead_code)]
+    #[config(validate = Self::validate)]
+    struct Conf {
+        foo: Option<u32>,
+        bar: Option<u32>,
+    }
+
+    impl Conf {
+        fn validate(&self) -> Result<(), &'static str> {
+            if !(self.foo.is_some() ^ self.bar.is_some()) {
+                return Err("exactly one of foo and bar must be set");
+            }
+            Ok(())
+        }
+    }
+
+    let load = |s: &str| {
+        let partial = toml::from_str::<<Conf as Config>::Partial>(s).unwrap();
+        Conf::from_partial(partial)
+    };
+
+    assert_eq!(load("foo = 123").unwrap(), Conf {
+        foo: Some(123),
+        bar: None,
+    });
+    assert_eq!(load("bar = 27").unwrap(), Conf {
+        foo: None,
+        bar: Some(27),
+    });
+    assert_err_contains(load(""), "exactly one of foo and bar must be set");
+    assert_err_contains(load("foo = 123\nbar=27"), "exactly one of foo and bar must be set");
+}
+
+#[track_caller]
+fn assert_err_contains<T, E: std::fmt::Display>(r: Result<T, E>, expected: &str) {
+    let e = r.map(|_| ()).unwrap_err();
+    let s = format!("{e:#}");
+    if !s.contains(expected) {
+        panic!("expected error msg to contain '{expected}', but it doesn't: \n{s}");
+    }
+}


### PR DESCRIPTION
Adds the `validate` attribute that can be attached to structs or struct fields. Its syntax is `validate = path::to::function` where the function takes `&T` and returns `Result<(), impl Display>`. For struct fields, a second `assert!`-style syntax exists: `validate(!name.is_empty(), "name must not be empty")`. 

See the added docs for more information.

Closes #16 