### PR TITLE
feat: support `partial_attr` for struct fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ toml = { version = "0.8", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
-derive_more = { version = "2.0.1", features = ["debug"] }
+derive_more = { version = "2.0.1", features = ["debug", "display", "deref"] }
 
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ toml = { version = "0.8", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
+derive_more = { version = "2.0.1", features = ["debug"] }
 
 
 [package.metadata.docs.rs]

--- a/macro/src/gen/meta.rs
+++ b/macro/src/gen/meta.rs
@@ -21,7 +21,7 @@ pub(super) fn gen(input: &ir::Input) -> TokenStream {
         let name = f.name.to_string();
         let doc =  &f.doc;
         let kind = match &f.kind {
-            FieldKind::Nested { ty, partial_attr: _ } => {
+            FieldKind::Nested { ty } => {
                 quote! {
                     confique::meta::FieldKind::Nested { meta: &<#ty as confique::Config>::META }
                 }

--- a/macro/src/gen/meta.rs
+++ b/macro/src/gen/meta.rs
@@ -21,7 +21,7 @@ pub(super) fn gen(input: &ir::Input) -> TokenStream {
         let name = f.name.to_string();
         let doc =  &f.doc;
         let kind = match &f.kind {
-            FieldKind::Nested { ty } => {
+            FieldKind::Nested { ty, partial_attr: _ } => {
                 quote! {
                     confique::meta::FieldKind::Nested { meta: &<#ty as confique::Config>::META }
                 }

--- a/macro/src/ir.rs
+++ b/macro/src/ir.rs
@@ -17,6 +17,7 @@ pub(crate) struct Field {
     pub(crate) doc: Vec<String>,
     pub(crate) name: syn::Ident,
     pub(crate) kind: FieldKind,
+    pub(crate) partial_attrs: Vec<TokenStream>
 
     // TODO:
     // - serde attributes
@@ -30,14 +31,12 @@ pub(crate) enum FieldKind {
         deserialize_with: Option<syn::Path>,
         parse_env: Option<syn::Path>,
         validate: Option<FieldValidator>,
-        partial_attr: Option<TokenStream>,
         kind: LeafKind,
     },
 
     /// A nested configuration. The type is never `Option<_>`.
     Nested {
         ty: syn::Type,
-        partial_attr: Option<TokenStream>
     },
 }
 

--- a/macro/src/ir.rs
+++ b/macro/src/ir.rs
@@ -30,12 +30,14 @@ pub(crate) enum FieldKind {
         deserialize_with: Option<syn::Path>,
         parse_env: Option<syn::Path>,
         validate: Option<FieldValidator>,
+        partial_attr: Option<TokenStream>,
         kind: LeafKind,
     },
 
     /// A nested configuration. The type is never `Option<_>`.
     Nested {
         ty: syn::Type,
+        partial_attr: Option<TokenStream>
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,8 @@ pub use crate::{
 /// For example, `#[config(partial_attr(derive(Clone)))]` can be used to make
 /// the partial type implement `Clone`.
 ///
+/// This attribute can also be applied to struct fields.
+///
 ///
 /// # What the macro generates
 ///

--- a/tests/partial_props.rs
+++ b/tests/partial_props.rs
@@ -5,32 +5,36 @@ use pretty_assertions::assert_eq;
 fn partial_props() {
     #[allow(dead_code)]
     #[derive(Config)]
-    #[config(partial_attr(derive(derive_more::Debug)))]
+    #[config(
+        partial_attr(derive(derive_more::Debug, derive_more::Display)),
+        partial_attr(display("{}", self.bar.unwrap_or_default())),
+    )]
     struct Foo {
         #[config(default = 1, partial_attr(debug("test {bar:?}")))]
         bar: u32,
     }
 
-    use confique_partial_foo::PartialFoo;
+    type PartialFoo = <Foo as Config>::Partial;
+
     let partial_foo = PartialFoo { bar: Some(1) };
     assert_eq!(
+        format!("{partial_foo:?}"),
         "PartialFoo { bar: test Some(1) }",
-        format!("{partial_foo:?}")
     );
+
+    assert_eq!(format!("{partial_foo}"), "1");
 }
 
 #[test]
 fn partial_props_nested() {
     mod foo {
         use confique::Config;
-        pub use confique_partial_bar::PartialBar;
-        pub use confique_partial_foo::PartialFoo;
 
         #[allow(dead_code)]
         #[derive(Config)]
-        #[config(partial_attr(derive(derive_more::Debug)))]
+        #[config(partial_attr(derive(derive_more::Debug, derive_more::Deref)))]
         pub struct Foo {
-            #[config(default = 1, partial_attr(debug("test {bar:?}")))]
+            #[config(default = 1, partial_attr(debug("test {bar:?}")), partial_attr(deref))]
             bar: u32,
         }
 
@@ -43,12 +47,15 @@ fn partial_props_nested() {
         }
     }
 
-    use foo::*;
+    type PartialFoo = <foo::Foo as Config>::Partial;
+    type PartialBar = <foo::Bar as Config>::Partial;
 
     let partial_foo = PartialFoo { bar: Some(1) };
+    assert_eq!(*partial_foo, Some(1));
+
     let partial_bar = PartialBar { foo2: partial_foo };
     assert_eq!(
+        format!("{partial_bar:?}"),
         "PartialBar { foo2: test2 PartialFoo { bar: test Some(1) } }",
-        format!("{partial_bar:?}")
     );
 }

--- a/tests/partial_props.rs
+++ b/tests/partial_props.rs
@@ -1,0 +1,54 @@
+use confique::Config;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn partial_props() {
+    #[allow(dead_code)]
+    #[derive(Config)]
+    #[config(partial_attr(derive(derive_more::Debug)))]
+    struct Foo {
+        #[config(default = 1, partial_attr(debug("test {bar:?}")))]
+        bar: u32,
+    }
+
+    use confique_partial_foo::PartialFoo;
+    let partial_foo = PartialFoo { bar: Some(1) };
+    assert_eq!(
+        "PartialFoo { bar: test Some(1) }",
+        format!("{partial_foo:?}")
+    );
+}
+
+#[test]
+fn partial_props_nested() {
+    mod foo {
+        use confique::Config;
+        pub use confique_partial_bar::PartialBar;
+        pub use confique_partial_foo::PartialFoo;
+
+        #[allow(dead_code)]
+        #[derive(Config)]
+        #[config(partial_attr(derive(derive_more::Debug)))]
+        pub struct Foo {
+            #[config(default = 1, partial_attr(debug("test {bar:?}")))]
+            bar: u32,
+        }
+
+        #[allow(dead_code)]
+        #[derive(Config)]
+        #[config(partial_attr(derive(derive_more::Debug)))]
+        pub struct Bar {
+            #[config(nested, partial_attr(debug("test2 {foo2:?}")))]
+            foo2: Foo,
+        }
+    }
+
+    use foo::*;
+
+    let partial_foo = PartialFoo { bar: Some(1) };
+    let partial_bar = PartialBar { foo2: partial_foo };
+    assert_eq!(
+        "PartialBar { foo2: test2 PartialFoo { bar: test Some(1) } }",
+        format!("{partial_bar:?}")
+    );
+}


### PR DESCRIPTION
Related to #19

This adds support for the existing derive attribute `partial_attr` in struct fields. This is useful if you need to derive something on the generated partial struct that requires specifying attributes on struct fields. Being able to derive clap's traits on the partial structs is the main motivation for this, but it also works for any other trait (derive_more is the example I chose for the test).

This is most of the work required to support using partial structs with clap. More info in this comment: https://github.com/LukasKalbertodt/confique/issues/19#issuecomment-2781177949