### PR TITLE
CI: update unsupported actions runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
   check:
     name: 'Build & test'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Restore Cache


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported so the runner needs to be updated.