### PR TITLE
Add more configuration options to confique::FormatOptions 

### DIFF
--- a/src/json5.rs
+++ b/src/json5.rs
@@ -225,6 +225,14 @@ mod tests {
     }
 
     #[test]
+    fn no_default_or_required_comment() {
+        let mut options = FormatOptions::default();
+        options.general.include_default_or_required_comment = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-no-default-required-comments.json5"));
+    }
+
+    #[test]
     fn immediately_nested() {
         let out = template::<test_utils::example2::Conf>(Default::default());
         assert_str_eq!(&out, include_format_output!("2-default.json5"));

--- a/src/json5.rs
+++ b/src/json5.rs
@@ -4,12 +4,10 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    Config,
-    template::{self, Formatter},
     meta::Expr,
+    template::{self, Formatter},
+    Config,
 };
-
-
 
 /// Options for generating a JSON5 template.
 #[non_exhaustive]
@@ -216,6 +214,14 @@ mod tests {
         options.general.comments = false;
         let out = template::<test_utils::example1::Conf>(options);
         assert_str_eq!(&out, include_format_output!("1-no-comments.json5"));
+    }
+
+    #[test]
+    fn uncommented_default() {
+        let mut options = FormatOptions::default();
+        options.general.comment_out_default_values = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-uncommented-defaults.json5"));
     }
 
     #[test]

--- a/src/json5.rs
+++ b/src/json5.rs
@@ -139,6 +139,12 @@ impl Formatter for Json5Formatter {
         writeln!(self.buffer, "//{comment}").unwrap();
     }
 
+    fn field(&mut self, name: &'static str, value: &'static Expr) {
+        self.emit_indentation();
+let value = PrintExpr(value);
+        writeln!(self.buffer, "{}", format_args!("{name}: {value},")).unwrap();
+    }
+
     fn disabled_field(&mut self, name: &str, value: Option<&'static Expr>) {
         match value.map(PrintExpr) {
             None => self.comment(format_args!("{name}: ,")),

--- a/src/json5.rs
+++ b/src/json5.rs
@@ -141,7 +141,7 @@ impl Formatter for Json5Formatter {
 
     fn field(&mut self, name: &'static str, value: &'static Expr) {
         self.emit_indentation();
-let value = PrintExpr(value);
+        let value = PrintExpr(value);
         writeln!(self.buffer, "{}", format_args!("{name}: {value},")).unwrap();
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -27,6 +27,9 @@ pub(crate) trait Formatter {
     /// your comment token.
     fn comment(&mut self, comment: impl fmt::Display);
 
+    /// Write a prepopulated field with a value, e.g. `format!("{name} = {value}")`.
+    fn field(&mut self, name: &'static str, value: &'static Expr);
+
     /// Write a commented-out field with optional value, e.g. `format!("#{name} = {value}")`.
     fn disabled_field(&mut self, name: &'static str, value: Option<&'static Expr>);
 
@@ -92,12 +95,18 @@ pub(crate) trait Formatter {
 /// General (non format-dependent) template-formatting options.
 #[non_exhaustive]
 pub struct FormatOptions {
-    /// Whether to include doc comments (with your own text). Default:
-    /// `true`.
+    /// Whether to include doc comments (with your own text).
+    ///
+    /// Default: `true`.
     pub comments: bool,
-    /// If to include information about whether a value is required and/or has a default). Default:
-    /// `true`.
+    /// If to include information about whether a value is required and/or has a default).
+    ///
+    /// Default: `true`.
     pub include_default_or_required_comment: bool,
+    /// Whether to comment out default values (f.e. `#foo = 3` vs. `foo = 3`).
+    ///
+    /// Default: `true`
+    pub comment_out_default_values: bool,
     /// If `comments` and this field are `true`, leaf fields with `env = "FOO"`
     /// attribute will have a line like this added:
     ///
@@ -107,21 +116,18 @@ pub struct FormatOptions {
     ///
     /// Default: `true`.
     pub env_keys: bool,
-
     /// Number of lines between leaf fields. Gap between leaf and nested fields
     /// is the bigger of this and `nested_field_gap`.
     ///
     /// Default: `if self.comments { 1 } else { 0 }`.
     pub leaf_field_gap: Option<u8>,
-
     /// Number of lines between nested fields. Gap between leaf and nested
     /// fields is the bigger of this and `leaf_field_gap`.
     ///
     /// Default: 1.
     pub nested_field_gap: u8,
-
+    
     // Potential future options:
-    // - Comment out default values (`#foo = 3` vs `foo = 3`)
     // - Which docs to include from nested objects
 }
 
@@ -136,6 +142,7 @@ impl Default for FormatOptions {
         Self {
             comments: true,
             include_default_or_required_comment: true,
+            comment_out_default_values: true,
             env_keys: true,
             leaf_field_gap: None,
             nested_field_gap: 1,
@@ -205,7 +212,15 @@ fn format_impl(out: &mut impl Formatter, meta: &Meta, options: &FormatOptions) {
                 }
 
                 // Emit the actual line with the name and optional value
-                out.disabled_field(field.name, default.as_ref());
+                if let Some(default_value) = default {
+                if options.comment_out_default_values {
+                    out.disabled_field(field.name, default.as_ref());
+                } else {
+                        out.field(field.name, default_value); 
+                    }
+                } else {
+                    out.disabled_field(field.name, default.as_ref());
+                }
             }
         }
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -92,11 +92,12 @@ pub(crate) trait Formatter {
 /// General (non format-dependent) template-formatting options.
 #[non_exhaustive]
 pub struct FormatOptions {
-    /// Whether to include doc comments (with your own text and information
-    /// about whether a value is required and/or has a default). Default:
+    /// Whether to include doc comments (with your own text). Default:
     /// `true`.
     pub comments: bool,
-
+    /// If to include information about whether a value is required and/or has a default). Default:
+    /// `true`.
+    pub include_default_or_required_comment: bool,
     /// If `comments` and this field are `true`, leaf fields with `env = "FOO"`
     /// attribute will have a line like this added:
     ///
@@ -134,6 +135,7 @@ impl Default for FormatOptions {
     fn default() -> Self {
         Self {
             comments: true,
+            include_default_or_required_comment: true,
             env_keys: true,
             leaf_field_gap: None,
             nested_field_gap: 1,
@@ -197,7 +199,7 @@ fn format_impl(out: &mut impl Formatter, meta: &Meta, options: &FormatOptions) {
             LeafKind::Optional => out.disabled_field(field.name, None),
             LeafKind::Required { default } => {
                 // Emit comment about default value or the value being required.
-                if options.comments {
+                if options.include_default_or_required_comment {
                     empty_sep_doc_line!();
                     out.default_or_required_comment(default.as_ref())
                 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -126,7 +126,7 @@ pub struct FormatOptions {
     ///
     /// Default: 1.
     pub nested_field_gap: u8,
-    
+
     // Potential future options:
     // - Which docs to include from nested objects
 }
@@ -212,12 +212,8 @@ fn format_impl(out: &mut impl Formatter, meta: &Meta, options: &FormatOptions) {
                 }
 
                 // Emit the actual line with the name and optional value
-                if let Some(default_value) = default {
-                if options.comment_out_default_values {
-                    out.disabled_field(field.name, default.as_ref());
-                } else {
-                        out.field(field.name, default_value); 
-                    }
+                if !options.comment_out_default_values && let Some(default_value) = default {
+                    out.field(field.name, default_value); 
                 } else {
                     out.disabled_field(field.name, default.as_ref());
                 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -206,17 +206,16 @@ fn format_impl(out: &mut impl Formatter, meta: &Meta, options: &FormatOptions) {
             LeafKind::Optional => out.disabled_field(field.name, None),
             LeafKind::Required { default } => {
                 // Emit comment about default value or the value being required.
-                if options.include_default_or_required_comment {
+                if options.include_default_or_required_comment && options.comments {
                     empty_sep_doc_line!();
                     out.default_or_required_comment(default.as_ref())
                 }
 
                 // Emit the actual line with the name and optional value
-                if !options.comment_out_default_values && let Some(default_value) = default {
-                    out.field(field.name, default_value); 
-                } else {
-                    out.disabled_field(field.name, default.as_ref());
-                }
+                match default {
+                    Some(ref default_value) if !options.comment_out_default_values => out.field(field.name, default_value),
+                    _ => out.disabled_field(field.name, default.as_ref())
+}
             }
         }
     }

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -248,6 +248,14 @@ mod tests {
     }
 
     #[test]
+    fn no_default_or_required_comment() {
+        let mut options = FormatOptions::default();
+        options.general.include_default_or_required_comment = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-no-default-required-comments.toml"));
+    }
+
+    #[test]
     fn indent_2() {
         let mut options = FormatOptions::default();
         options.indent = 2;

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -240,6 +240,14 @@ mod tests {
     }
 
     #[test]
+    fn uncommented_default() {
+        let mut options = FormatOptions::default();
+        options.general.comment_out_default_values = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-uncommented-defaults.toml"));
+    }
+
+    #[test]
     fn indent_2() {
         let mut options = FormatOptions::default();
         options.indent = 2;

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -130,6 +130,12 @@ impl Formatter for TomlFormatter {
         writeln!(self.buffer, "#{comment}").unwrap();
     }
 
+    fn field(&mut self, name: &'static str, value: &'static Expr) {
+        self.emit_indentation();
+        let value = PrintExpr(value);
+        writeln!(self.buffer, "{name} = {value}").unwrap();
+    }
+
     fn disabled_field(&mut self, name: &str, value: Option<&'static Expr>) {
         match value.map(PrintExpr) {
             None => self.comment(format_args!("{name} =")),

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -132,6 +132,12 @@ impl Formatter for YamlFormatter {
         writeln!(self.buffer, "#{comment}").unwrap();
     }
 
+    fn field(&mut self, name: &'static str, value: &'static Expr) {
+        self.emit_indentation();
+        let value = PrintExpr(value);
+        writeln!(self.buffer, "{name}: {value}").unwrap();
+    }
+
     fn disabled_field(&mut self, name: &str, value: Option<&'static Expr>) {
         match value.map(PrintExpr) {
             None => self.comment(format_args!("{name}:")),

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -260,6 +260,14 @@ mod tests {
     }
 
     #[test]
+    fn no_default_or_required_comment() {
+        let mut options = FormatOptions::default();
+        options.general.include_default_or_required_comment = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-no-default-required-comments.yaml"));
+    }
+
+    #[test]
     fn immediately_nested() {
         let out = template::<test_utils::example2::Conf>(Default::default());
         assert_str_eq!(&out, include_format_output!("2-default.yaml"));

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -252,6 +252,14 @@ mod tests {
     }
 
     #[test]
+    fn uncommented_default() {
+        let mut options = FormatOptions::default();
+        options.general.comment_out_default_values = false;
+        let out = template::<test_utils::example1::Conf>(options);
+        assert_str_eq!(&out, include_format_output!("1-uncommented-defaults.yaml"));
+    }
+
+    #[test]
     fn immediately_nested() {
         let out = template::<test_utils::example2::Conf>(Default::default());
         assert_str_eq!(&out, include_format_output!("2-default.yaml"));

--- a/tests/format-output/1-no-default-required-comments.json5
+++ b/tests/format-output/1-no-default-required-comments.json5
@@ -1,0 +1,41 @@
+// A sample configuration for our app.
+{
+  // Name of the website.
+  //site_name: ,
+
+  // Configurations related to the HTTP communication.
+  http: {
+    // The port the server will listen on.
+    //
+    // Can also be specified via environment variable `PORT`.
+    //port: ,
+
+    // The bind address of the server. Can be set to `0.0.0.0` for example, to
+    // allow other users of the network to access the server.
+    //bind: "127.0.0.1",
+
+    headers: {
+      // The header in which the reverse proxy specifies the username.
+      //username: "x-username",
+
+      // The header in which the reverse proxy specifies the display name.
+      //display_name: "x-display-name",
+
+      // Headers that are allowed.
+      //allowed: ["content-type","content-encoding"],
+
+      // Assigns a score to some headers.
+      //score: {"cookie":1.5,"server":12.7},
+    },
+  },
+
+  // Configuring the logging.
+  log: {
+    // If set to `true`, the app will log to stdout.
+    //stdout: true,
+
+    // If this is set, the app will write logs to the given file. Of course,
+    // the app has to have write access to that file.
+    //file: ,
+  },
+}

--- a/tests/format-output/1-no-default-required-comments.toml
+++ b/tests/format-output/1-no-default-required-comments.toml
@@ -1,0 +1,37 @@
+# A sample configuration for our app.
+
+# Name of the website.
+#site_name =
+
+# Configurations related to the HTTP communication.
+[http]
+# The port the server will listen on.
+#
+# Can also be specified via environment variable `PORT`.
+#port =
+
+# The bind address of the server. Can be set to `0.0.0.0` for example, to
+# allow other users of the network to access the server.
+#bind = "127.0.0.1"
+
+[http.headers]
+# The header in which the reverse proxy specifies the username.
+#username = "x-username"
+
+# The header in which the reverse proxy specifies the display name.
+#display_name = "x-display-name"
+
+# Headers that are allowed.
+#allowed = ["content-type", "content-encoding"]
+
+# Assigns a score to some headers.
+#score = { cookie = 1.5, server = 12.7 }
+
+# Configuring the logging.
+[log]
+# If set to `true`, the app will log to stdout.
+#stdout = true
+
+# If this is set, the app will write logs to the given file. Of course,
+# the app has to have write access to that file.
+#file =

--- a/tests/format-output/1-no-default-required-comments.yaml
+++ b/tests/format-output/1-no-default-required-comments.yaml
@@ -1,0 +1,37 @@
+# A sample configuration for our app.
+
+# Name of the website.
+#site_name:
+
+# Configurations related to the HTTP communication.
+http:
+  # The port the server will listen on.
+  #
+  # Can also be specified via environment variable `PORT`.
+  #port:
+
+  # The bind address of the server. Can be set to `0.0.0.0` for example, to
+  # allow other users of the network to access the server.
+  #bind: 127.0.0.1
+
+  headers:
+    # The header in which the reverse proxy specifies the username.
+    #username: x-username
+
+    # The header in which the reverse proxy specifies the display name.
+    #display_name: x-display-name
+
+    # Headers that are allowed.
+    #allowed: [content-type, content-encoding]
+
+    # Assigns a score to some headers.
+    #score: { cookie: 1.5, server: 12.7 }
+
+# Configuring the logging.
+log:
+  # If set to `true`, the app will log to stdout.
+  #stdout: true
+
+  # If this is set, the app will write logs to the given file. Of course,
+  # the app has to have write access to that file.
+  #file:

--- a/tests/format-output/1-uncommented-defaults.json5
+++ b/tests/format-output/1-uncommented-defaults.json5
@@ -1,0 +1,57 @@
+// A sample configuration for our app.
+{
+  // Name of the website.
+  //
+  // Required! This value must be specified.
+  //site_name: ,
+
+  // Configurations related to the HTTP communication.
+  http: {
+    // The port the server will listen on.
+    //
+    // Can also be specified via environment variable `PORT`.
+    //
+    // Required! This value must be specified.
+    //port: ,
+
+    // The bind address of the server. Can be set to `0.0.0.0` for example, to
+    // allow other users of the network to access the server.
+    //
+    // Default value: "127.0.0.1"
+    bind: "127.0.0.1",
+
+    headers: {
+      // The header in which the reverse proxy specifies the username.
+      //
+      // Default value: "x-username"
+      username: "x-username",
+
+      // The header in which the reverse proxy specifies the display name.
+      //
+      // Default value: "x-display-name"
+      display_name: "x-display-name",
+
+      // Headers that are allowed.
+      //
+      // Default value: ["content-type","content-encoding"]
+      allowed: ["content-type","content-encoding"],
+
+      // Assigns a score to some headers.
+      //
+      // Default value: {"cookie":1.5,"server":12.7}
+      score: {"cookie":1.5,"server":12.7},
+    },
+  },
+
+  // Configuring the logging.
+  log: {
+    // If set to `true`, the app will log to stdout.
+    //
+    // Default value: true
+    stdout: true,
+
+    // If this is set, the app will write logs to the given file. Of course,
+    // the app has to have write access to that file.
+    //file: ,
+  },
+}

--- a/tests/format-output/1-uncommented-defaults.toml
+++ b/tests/format-output/1-uncommented-defaults.toml
@@ -1,0 +1,53 @@
+# A sample configuration for our app.
+
+# Name of the website.
+#
+# Required! This value must be specified.
+#site_name =
+
+# Configurations related to the HTTP communication.
+[http]
+# The port the server will listen on.
+#
+# Can also be specified via environment variable `PORT`.
+#
+# Required! This value must be specified.
+#port =
+
+# The bind address of the server. Can be set to `0.0.0.0` for example, to
+# allow other users of the network to access the server.
+#
+# Default value: "127.0.0.1"
+bind = "127.0.0.1"
+
+[http.headers]
+# The header in which the reverse proxy specifies the username.
+#
+# Default value: "x-username"
+username = "x-username"
+
+# The header in which the reverse proxy specifies the display name.
+#
+# Default value: "x-display-name"
+display_name = "x-display-name"
+
+# Headers that are allowed.
+#
+# Default value: ["content-type", "content-encoding"]
+allowed = ["content-type", "content-encoding"]
+
+# Assigns a score to some headers.
+#
+# Default value: { cookie = 1.5, server = 12.7 }
+score = { cookie = 1.5, server = 12.7 }
+
+# Configuring the logging.
+[log]
+# If set to `true`, the app will log to stdout.
+#
+# Default value: true
+stdout = true
+
+# If this is set, the app will write logs to the given file. Of course,
+# the app has to have write access to that file.
+#file =

--- a/tests/format-output/1-uncommented-defaults.yaml
+++ b/tests/format-output/1-uncommented-defaults.yaml
@@ -1,0 +1,53 @@
+# A sample configuration for our app.
+
+# Name of the website.
+#
+# Required! This value must be specified.
+#site_name:
+
+# Configurations related to the HTTP communication.
+http:
+  # The port the server will listen on.
+  #
+  # Can also be specified via environment variable `PORT`.
+  #
+  # Required! This value must be specified.
+  #port:
+
+  # The bind address of the server. Can be set to `0.0.0.0` for example, to
+  # allow other users of the network to access the server.
+  #
+  # Default value: 127.0.0.1
+  bind: 127.0.0.1
+
+  headers:
+    # The header in which the reverse proxy specifies the username.
+    #
+    # Default value: x-username
+    username: x-username
+
+    # The header in which the reverse proxy specifies the display name.
+    #
+    # Default value: x-display-name
+    display_name: x-display-name
+
+    # Headers that are allowed.
+    #
+    # Default value: [content-type, content-encoding]
+    allowed: [content-type, content-encoding]
+
+    # Assigns a score to some headers.
+    #
+    # Default value: { cookie: 1.5, server: 12.7 }
+    score: { cookie: 1.5, server: 12.7 }
+
+# Configuring the logging.
+log:
+  # If set to `true`, the app will log to stdout.
+  #
+  # Default value: true
+  stdout: true
+
+  # If this is set, the app will write logs to the given file. Of course,
+  # the app has to have write access to that file.
+  #file:


### PR DESCRIPTION
I've added two new options to `FormatOptions`:
- `include_default_or_required_comment` (controls whether to include comments about required/default values) _and_
- `comment_out_default_values` (controls whether default values are commented out or written as active fields).

Both default to `true`. 

To achieve `comment_out_default_values`, I've added a new `field` method to the `Formatter` trait for emitting a field with its value.

**Some Examples:**

- Default Options:

<table>
<tr>
    <td><code>toml::template::&lt;Conf&gt;()</code></td>
    <td><code>yaml::template::&lt;Conf&gt;()</code></td>
    <td><code>json5::template::&lt;Conf&gt;()</code></td>
</tr>
<tr>
<td>

```toml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#
# Default value: 8080
#port = 8080

# Bind address.
#
# Default value: "127.0.0.1"
#address = "127.0.0.1"

[log]
# Default value: true
#stdout = true

#file =

# Default value: ["debug"]
#ignored_modules = ["debug"]
```

</td>
<td>

```yaml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#
# Default value: 8080
#port: 8080

# Bind address.
#
# Default value: 127.0.0.1
#address: 127.0.0.1

log:
  # Default value: true
  #stdout: true

  #file:

  # Default value: [debug]
  #ignored_modules: [debug]
```

</td>
<td>

```json5
{
  // Port to listen on.
  //
  // Can also be specified via environment variable `PORT`.
  //
  // Default value: 8080
  //port: 8080,

  // Bind address.
  //
  // Default value: "127.0.0.1"
  //address: "127.0.0.1",

  log: {
    // Default value: true
    //stdout: true,

    //file: ,

    // Default value: ["debug"]
    //ignored_modules: ["debug"],
  },
}
```

</td>
</tr>
</table>

- `FormatOptions::comment_out_default_values = false`

<table>
<tr>
    <td><code>toml::template::&lt;Conf&gt;()</code></td>
    <td><code>yaml::template::&lt;Conf&gt;()</code></td>
    <td><code>json5::template::&lt;Conf&gt;()</code></td>
</tr>
<tr>
<td>

```toml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#
# Default value: 8080
port = 8080

# Bind address.
#
# Default value: "127.0.0.1"
address = "127.0.0.1"

[log]
# Default value: true
stdout = true

#file =

# Default value: ["debug"]
ignored_modules = ["debug"]
```

</td>
<td>

```yaml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#
# Default value: 8080
port: 8080

# Bind address.
#
# Default value: 127.0.0.1
address: 127.0.0.1

log:
  # Default value: true
  stdout: true

  #file:

  # Default value: [debug]
  ignored_modules: [debug]
```

</td>
<td>

```json5
{
  // Port to listen on.
  //
  // Can also be specified via environment variable `PORT`.
  //
  // Default value: 8080
  port: 8080,

  // Bind address.
  //
  // Default value: "127.0.0.1"
  address: "127.0.0.1",

  log: {
    // Default value: true
    stdout: true,

    //file: ,

    // Default value: ["debug"]
    ignored_modules: ["debug"],
  },
}
```

</td>
</tr>
</table>

- `FormatOptions::include_default_or_required_comment = false`

<table>
<tr>
    <td><code>toml::template::&lt;Conf&gt;()</code></td>
    <td><code>yaml::template::&lt;Conf&gt;()</code></td>
    <td><code>json5::template::&lt;Conf&gt;()</code></td>
</tr>
<tr>
<td>

```toml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#port = 8080

# Bind address.
#address = "127.0.0.1"

[log]
#stdout = true

#file =

#ignored_modules = ["debug"]
```

</td>
<td>

```yaml
# Port to listen on.
#
# Can also be specified via environment variable `PORT`.
#port: 8080

# Bind address.
#address: 127.0.0.1

log:
  #stdout: true

  #file:

  #ignored_modules: [debug]
```

</td>
<td>

```json5
{
  // Port to listen on.
  //
  // Can also be specified via environment variable `PORT`.
  //port: 8080,

  // Bind address.
  //address: "127.0.0.1",

  log: {
    //stdout: true,

    //file: ,

    //ignored_modules: ["debug"],
  },
}
```

</td>
</tr>
</table>